### PR TITLE
feat: GA4 이벤트 수집 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 	// ULID 생성 라이브러리 (Request ID 추적용)
 	implementation 'com.github.f4b6a3:ulid-creator:5.2.3'
 
+	// Apache HttpClient 5.x (RestTemplate 사용, GA4 이벤트 전송용)
+	implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/vibe/scon/scon_backend/config/RestTemplateConfig.java
+++ b/src/main/java/vibe/scon/scon_backend/config/RestTemplateConfig.java
@@ -1,0 +1,67 @@
+package vibe.scon.scon_backend.config;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RestTemplate 설정.
+ * 
+ * <p>GA4 Measurement Protocol API 호출을 위한 RestTemplate Bean을 설정합니다.</p>
+ * 
+ * <h3>주요 설정:</h3>
+ * <ul>
+ *   <li>Connection Pool: 최대 100개, 라우트당 20개</li>
+ *   <li>타임아웃: 연결/요청/응답 모두 5초</li>
+ *   <li>Idle Connection 정리: 30초</li>
+ * </ul>
+ * 
+ * <h3>요구사항 추적:</h3>
+ * <ul>
+ *   <li>{@code BE_GA4.md Phase 1.2}: RestTemplate Bean 생성</li>
+ * </ul>
+ * 
+ * @see RestTemplate
+ */
+@Configuration
+public class RestTemplateConfig {
+    
+    /**
+     * RestTemplate Bean 생성.
+     * 
+     * <p>Apache HttpClient 5.x를 사용하여 Connection Pool과 타임아웃을 설정합니다.</p>
+     * 
+     * @return RestTemplate 인스턴스
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        // Connection Pool 설정
+        PoolingHttpClientConnectionManager connectionManager = 
+            new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(100);
+        connectionManager.setDefaultMaxPerRoute(20);
+        
+        // HTTP Client 생성
+        CloseableHttpClient httpClient = HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .evictIdleConnections(Timeout.of(30, TimeUnit.SECONDS))
+            .evictExpiredConnections()
+            .build();
+        
+        // Request Factory 설정
+        HttpComponentsClientHttpRequestFactory factory = 
+            new HttpComponentsClientHttpRequestFactory(httpClient);
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setConnectionRequestTimeout(Duration.ofSeconds(5));
+        
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/vibe/scon/scon_backend/service/AnalyticsService.java
+++ b/src/main/java/vibe/scon/scon_backend/service/AnalyticsService.java
@@ -1,0 +1,109 @@
+package vibe.scon.scon_backend.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Google Analytics 4 (GA4) 이벤트 전송 서비스.
+ * 
+ * <p>GA4 Measurement Protocol을 사용하여 서버 사이드 이벤트를 전송합니다.</p>
+ * 
+ * <h3>주요 기능:</h3>
+ * <ul>
+ *   <li>비동기 이벤트 전송 (@Async 사용)</li>
+ *   <li>에러 발생 시에도 비즈니스 로직에 영향 없음</li>
+ *   <li>MDC 전파를 통한 로그 추적 지원</li>
+ * </ul>
+ * 
+ * <h3>요구사항 추적:</h3>
+ * <ul>
+ *   <li>{@code BE_GA4.md Phase 1.4}: AnalyticsService 생성</li>
+ * </ul>
+ * 
+ * @see <a href="https://developers.google.com/analytics/devguides/collection/protocol/ga4">GA4 Measurement Protocol</a>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsService {
+    
+    private final RestTemplate restTemplate;
+    
+    @Value("${analytics.ga4.enabled:true}")
+    private boolean enabled;
+    
+    @Value("${analytics.ga4.measurement-id:}")
+    private String measurementId;
+    
+    @Value("${analytics.ga4.api-secret:}")
+    private String apiSecret;
+    
+    private static final String GA4_ENDPOINT = "https://www.google-analytics.com/mp/collect";
+    
+    /**
+     * GA4 이벤트 전송 (비동기).
+     * 
+     * <p>비동기 작업에서 실행되지만, TaskDecorator를 통해 MDC가 전파되므로
+     * 로그에 requestId가 포함됩니다.</p>
+     * 
+     * <p>GA4 전송 실패 시에도 비즈니스 로직에 영향을 주지 않도록
+     * 예외를 잡아 로그만 기록합니다.</p>
+     * 
+     * @param userId 사용자 ID (필수)
+     * @param sessionId 세션 ID (필수, Request ID 사용)
+     * @param eventName 이벤트명 (필수)
+     * @param parameters 추가 매개변수
+     */
+    @Async("taskExecutor")
+    public void logEvent(String userId, String sessionId, String eventName, Map<String, Object> parameters) {
+        // GA4 비활성화 시 스킵
+        if (!enabled || measurementId == null || measurementId.isEmpty() || 
+            apiSecret == null || apiSecret.isEmpty()) {
+            log.debug("GA4 is disabled or not configured. Skipping event: {}", eventName);
+            return;
+        }
+        
+        try {
+            // 공통 매개변수 추가
+            Map<String, Object> enrichedParams = new HashMap<>(parameters);
+            enrichedParams.put("user_id", userId);
+            enrichedParams.put("session_id", sessionId);
+            
+            // GA4 Measurement Protocol URL
+            String url = String.format(
+                "%s?measurement_id=%s&api_secret=%s",
+                GA4_ENDPOINT, measurementId, apiSecret
+            );
+            
+            // 페이로드 구성
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("client_id", userId); // GA4에서 사용자 식별
+            payload.put("user_id", userId);   // 커스텀 사용자 ID
+            
+            Map<String, Object> event = new HashMap<>();
+            event.put("name", eventName);
+            event.put("params", enrichedParams);
+            
+            payload.put("events", List.of(event));
+            
+            // HTTP POST 요청 전송 (비동기)
+            restTemplate.postForObject(url, payload, String.class);
+            
+            // MDC의 requestId가 로그에 포함됨 (TaskDecorator를 통해 전파됨)
+            log.debug("GA4 event sent successfully: event={}, user_id={}", eventName, userId);
+            
+        } catch (Exception e) {
+            // 분석 이벤트 전송 실패가 비즈니스 로직에 영향을 주지 않도록 로그만 기록
+            log.error("Failed to send GA4 event: event={}, user_id={}, error={}", 
+                eventName, userId, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -110,3 +110,15 @@ app:
     enable-request-logging: ${ENABLE_API_REQUEST_LOGGING:true}
     # API 응답 로깅 활성화 여부 (기본값: true)
     enable-response-logging: ${ENABLE_API_RESPONSE_LOGGING:true}
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Google Analytics 4 (GA4) Configuration
+  # ─────────────────────────────────────────────────────────────────────────
+  analytics:
+    ga4:
+      # GA4 활성화 여부 (기본값: true)
+      enabled: ${GA4_ENABLED:true}
+      # GA4 Measurement ID (프로덕션에서는 환경 변수로 오버라이드 필수)
+      measurement-id: ${GA4_MEASUREMENT_ID:G-5LKZWVK4NY}
+      # GA4 API Secret (프로덕션에서는 환경 변수로 오버라이드 필수)
+      api-secret: ${GA4_API_SECRET:d2UPSS0MR86U8a0ayC9wsA}


### PR DESCRIPTION
## Implementation Overview

GA4 Measurement Protocol을 통한 서버 사이드 이벤트 추적 기능을 구현했습니다.

## 주요 변경사항

### Phase 1: 인프라 구축
- ✅ `application.yml`에 GA4 설정 추가 (Measurement ID: G-5LKZWVK4NY)
- ✅ `RestTemplateConfig` 생성 (Apache HttpClient 5.x)
- ✅ `AsyncConfig`에 `TaskDecorator` 추가 (MDC 전파)
- ✅ `AnalyticsService` 생성 (비동기 이벤트 전송)

### Phase 2: 핵심 이벤트 구현
- ✅ `sign_up`: 회원가입 완료 (AuthController)
- ✅ `login`: 로그인 성공 (AuthController)
- ✅ `scon_onboarding_step2_complete`: 매장 생성 완료 (StoreController)
- ✅ `scon_onboarding_step3_complete`: 첫 직원 등록 완료 (EmployeeController)

## 생성된 파일
- `src/main/java/vibe/scon/scon_backend/config/RestTemplateConfig.java`
- `src/main/java/vibe/scon/scon_backend/service/AnalyticsService.java`

## 수정된 파일
- `src/main/resources/application.yml` - GA4 설정 추가
- `build.gradle` - Apache HttpClient 의존성 추가
- `src/main/java/vibe/scon/scon_backend/config/AsyncConfig.java` - TaskDecorator 추가
- `src/main/java/vibe/scon/scon_backend/controller/AuthController.java` - sign_up, login 이벤트
- `src/main/java/vibe/scon/scon_backend/controller/StoreController.java` - scon_onboarding_step2_complete 이벤트
- `src/main/java/vibe/scon/scon_backend/controller/EmployeeController.java` - scon_onboarding_step3_complete 이벤트

## 빌드 결과
```bash
$ ./gradlew clean build -x test
BUILD SUCCESSFUL in 31s
```

## 특징
- 비동기 처리로 비즈니스 로직에 영향 없음
- MDC 전파를 통한 로그 추적 지원
- 에러 발생 시에도 비즈니스 로직 정상 동작

## 참고 문서
- SCON-Update-Plan/GA4/BE_GA4.md

## 다음 단계
- [ ] 개발 환경에서 실제 GA4 API 호출 테스트
- [ ] GA4 DebugView에서 이벤트 수신 확인
- [ ] 단위 테스트 작성 (선택사항)
